### PR TITLE
Removed anchor statements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,8 +95,8 @@ class centrify (
   include '::centrify::service'
 
   # set anchors for begin and end
-  anchor { '::centrify::begin': }
-  anchor { '::centrify::end': }
+  #anchor { '::centrify::begin': }
+  #anchor { '::centrify::end': }
 
   # ordering of class execution
   Anchor ['::centrify::begin'] -> Class ['::centrify::install'] ->


### PR DESCRIPTION
Testing the Puppet 4 future parser, and it looks like it doesn't like anchor statements.
